### PR TITLE
Allow the geo: tel: and sms: protocols

### DIFF
--- a/src/com/google/caja/plugin/UriPolicyNanny.java
+++ b/src/com/google/caja/plugin/UriPolicyNanny.java
@@ -46,8 +46,11 @@ public class UriPolicyNanny {
   private static boolean isAllowedScheme(String scheme) {
     scheme = Strings.lower(scheme);
     return (
+        "geo".equals(scheme) ||
         "http".equals(scheme) ||
         "https".equals(scheme) ||
-        "mailto".equals(scheme));
+        "mailto".equals(scheme) ||
+        "sms".equals(scheme) ||
+        "tel".equals(scheme));
   }
 }


### PR DESCRIPTION
"tel" is defined in multiple RFC's, event if it is not "the standard". I have yet to run across a mobile phone which does not support this.
"sms" has also turned into "a standard way" to start a text message.
"geo" is the most standard way to open maps, and supported on all phones. (https://en.wikipedia.org/wiki/Geo_URI_scheme)

Actually, why don't we support all the "Permanent" URI schemes from http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml?
It might be a bit of work and take updating every few years (standards don't move THAT fast!), but at least be modern!

Google Sites uses Caja (I think) to validate what the users can add to their sites, and because of the above not being implemented, hampers any attempt to make a truly useful mobile website.

Thank you for considering this.